### PR TITLE
Add leads feature

### DIFF
--- a/full-kit/prisma/schema.prisma
+++ b/full-kit/prisma/schema.prisma
@@ -81,3 +81,23 @@ model VerificationToken {
 
   @@unique([identifier, token])
 }
+model Customer {
+  id        String  @id @default(uuid())
+  name      String
+  email     String?
+  phone     String?
+  leads     Lead[]
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Lead {
+  id          String   @id @default(uuid())
+  title       String
+  description String?
+  status      String   @default("NEW")
+  customer    Customer? @relation(fields: [customerId], references: [id], onDelete: Cascade)
+  customerId  String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}

--- a/full-kit/src/app/[lang]/(dashboard-layout)/leads/[id]/page.tsx
+++ b/full-kit/src/app/[lang]/(dashboard-layout)/leads/[id]/page.tsx
@@ -1,0 +1,20 @@
+import { db } from "@/lib/prisma"
+
+export default async function LeadViewPage(props: { params: { id: string } }) {
+  const lead = await db.lead.findUnique({
+    where: { id: props.params.id },
+    include: { customer: true },
+  })
+
+  if (!lead) {
+    return <div className="p-4">Lead not found</div>
+  }
+
+  return (
+    <section className="container p-4 space-y-2">
+      <h1 className="text-2xl font-bold">{lead.title}</h1>
+      {lead.description && <p>{lead.description}</p>}
+      {lead.customer && <p>Customer: {lead.customer.name}</p>}
+    </section>
+  )
+}

--- a/full-kit/src/app/[lang]/(dashboard-layout)/leads/create/page.tsx
+++ b/full-kit/src/app/[lang]/(dashboard-layout)/leads/create/page.tsx
@@ -1,0 +1,58 @@
+import { redirect } from "next/navigation"
+
+import { db } from "@/lib/prisma"
+
+async function createLead(formData: FormData) {
+  "use server"
+  const title = String(formData.get("title"))
+  const description = String(formData.get("description") ?? "")
+  const customerName = String(formData.get("customer") ?? "")
+
+  let customer = await db.customer.findFirst({ where: { name: customerName } })
+  if (!customer && customerName) {
+    customer = await db.customer.create({ data: { name: customerName } })
+  }
+
+  const lead = await db.lead.create({
+    data: {
+      title,
+      description,
+      customerId: customer?.id,
+    },
+  })
+
+  redirect(`/leads/${lead.id}`)
+}
+
+export default function CreateLeadPage() {
+  return (
+    <form action={createLead} className="container p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Create Lead</h1>
+      <div>
+        <input
+          name="title"
+          placeholder="Title"
+          className="w-full border px-3 py-2"
+          required
+        />
+      </div>
+      <div>
+        <textarea
+          name="description"
+          placeholder="Description"
+          className="w-full border px-3 py-2"
+        />
+      </div>
+      <div>
+        <input
+          name="customer"
+          placeholder="Customer"
+          className="w-full border px-3 py-2"
+        />
+      </div>
+      <button type="submit" className="px-4 py-2 border">
+        Save
+      </button>
+    </form>
+  )
+}

--- a/full-kit/src/app/[lang]/(dashboard-layout)/leads/page.tsx
+++ b/full-kit/src/app/[lang]/(dashboard-layout)/leads/page.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link"
+
+import { db } from "@/lib/prisma"
+
+export default async function LeadsPage() {
+  const leads = await db.lead.findMany({ include: { customer: true } })
+  return (
+    <section className="container p-4">
+      <div className="mb-4 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Leads</h1>
+        <Link className="underline" href="/leads/create">
+          Create Lead
+        </Link>
+      </div>
+      <ul className="space-y-2">
+        {leads.map((lead) => (
+          <li key={lead.id}>
+            <Link className="underline" href={`/leads/${lead.id}`}>
+              {lead.title}
+            </Link>
+            {lead.customer ? ` - ${lead.customer.name}` : ""}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/full-kit/src/data/navigations.ts
+++ b/full-kit/src/data/navigations.ts
@@ -142,6 +142,20 @@ export const navigationsData: NavigationType[] = [
         ],
       },
       {
+        title: "Leads",
+        iconName: "UserPlus",
+        items: [
+          {
+            title: "List",
+            href: "/leads",
+          },
+          {
+            title: "Create",
+            href: "/leads/create",
+          },
+        ],
+      },
+      {
         title: "Customers",
         iconName: "Users",
         items: [


### PR DESCRIPTION
## Summary
- implement Lead and Customer models in Prisma
- add pages to list, create, and view leads
- hook new pages into dashboard navigation

## Testing
- `pnpm --filter ./full-kit lint`
- `pnpm --filter ./full-kit exec prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_684d5673741c83279dff4ce60cdf1d8c